### PR TITLE
Get real client IP

### DIFF
--- a/lib/greecex_web/endpoint.ex
+++ b/lib/greecex_web/endpoint.ex
@@ -38,7 +38,7 @@ defmodule GreecexWeb.Endpoint do
     param_key: "request_logger",
     cookie_key: "request_logger"
 
-  plug RemoteIp, headers: ["fly-client-ip"]
+  plug RemoteIp, headers: ["fly-client-ip"], proxies: ["66.241.124.124"]
 
   plug Plug.RequestId
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]

--- a/lib/greecex_web/live/debug_live.ex
+++ b/lib/greecex_web/live/debug_live.ex
@@ -7,13 +7,32 @@ defmodule GreecexWeb.DebugLive do
     peer_data = get_connect_info(socket, :peer_data)
     x_headers = get_connect_info(socket, :x_headers)
 
-    address = RemoteIp.from(x_headers)
+    address =
+      RemoteIp.from(x_headers, proxies: ["66.241.124.124"])
+
+    address_as_string =
+      cond do
+        address != nil ->
+          address
+          |> Tuple.to_list()
+          |> Enum.join(".")
+
+        true ->
+          nil
+      end
+
+    # address =
+    #   RemoteIp.from([{"x-forwarded-for", "45.66.42.184, 66.241.124.124"}],
+    #     proxies: ["66.241.124.124"]
+    #   )
+    #   |> Tuple.to_list()
+    #   |> Enum.join(".")
 
     {:ok,
      assign(socket,
        page_title: "Debug",
        peer_data: peer_data,
-       address: address,
+       address: address_as_string,
        x_headers: x_headers
      )}
   end

--- a/lib/greecex_web/live/debug_live.ex
+++ b/lib/greecex_web/live/debug_live.ex
@@ -18,7 +18,7 @@ defmodule GreecexWeb.DebugLive do
           |> Enum.join(".")
 
         true ->
-          nil
+          peer_data.address |> Tuple.to_list() |> Enum.join(".")
       end
 
     # address =


### PR DESCRIPTION
By configuring the `:proxies` option withe Fly.io's app related IP, RemoteIp returns the real client IP.