### PR TITLE
Propose home page design tweaks

### DIFF
--- a/lib/greecex_web/live/home_live.ex
+++ b/lib/greecex_web/live/home_live.ex
@@ -7,7 +7,7 @@ defmodule GreecexWeb.HomeLive do
 
   def render(assigns) do
     ~H"""
-    <div class="max-w-3xl mx-auto text-center px-6">
+    <div class="max-w-3xl mx-auto text-center">
       <h1 class="text-3xl font-extrabold text-gray-900 tracking-tight">
         Elixir is amazing!
       </h1>

--- a/lib/greecex_web/live/home_live.ex
+++ b/lib/greecex_web/live/home_live.ex
@@ -29,7 +29,7 @@ defmodule GreecexWeb.HomeLive do
       </div>
 
       <div class="mt-8 space-y-4">
-        <h2 class="text-base font-semibold text-gray-900">
+        <h2 class="text-lg font-semibold text-gray-900">
           Why subscribe to updates?
         </h2>
       </div>

--- a/lib/greecex_web/live/home_live.ex
+++ b/lib/greecex_web/live/home_live.ex
@@ -19,7 +19,7 @@ defmodule GreecexWeb.HomeLive do
         streamline development by reducing context switching.
       </p>
 
-      <div class="mt-12 mb-12 text-center space-y-4">
+      <div class="mt-4 mb-12 text-center space-y-4">
         <.link
           navigate={~p"/subscribe"}
           class="rounded-md bg-purple-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-purple-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-600"

--- a/lib/greecex_web/live/home_live.ex
+++ b/lib/greecex_web/live/home_live.ex
@@ -34,7 +34,7 @@ defmodule GreecexWeb.HomeLive do
         </h2>
       </div>
 
-      <div class="mx-auto mt-4 max-w-7xl px-6 sm:mt-4 md:mt-4 lg:px-8 text-left">
+      <div class="mx-auto mt-4 max-w-7xl sm:mt-4 md:mt-4 text-left">
         <dl class="mx-auto grid max-w-2xl grid-cols-1 gap-x-6 gap-y-6 text-sm text-gray-600 sm:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-3 lg:gap-x-8 lg:gap-y-8">
           <div class="relative pl-9">
             <dt class="inline font-semibold text-gray-900">

--- a/lib/greecex_web/live/home_live.ex
+++ b/lib/greecex_web/live/home_live.ex
@@ -28,7 +28,7 @@ defmodule GreecexWeb.HomeLive do
         </.link>
       </div>
 
-      <div class="mt-8 text-left space-y-4">
+      <div class="mt-8 space-y-4">
         <h2 class="text-base font-semibold text-gray-900">
           Why subscribe to updates?
         </h2>

--- a/lib/greecex_web/live/home_live.ex
+++ b/lib/greecex_web/live/home_live.ex
@@ -106,14 +106,14 @@ defmodule GreecexWeb.HomeLive do
           <h2 class="max-w-2xl text-2xl font-semibold tracking-tight text-gray-900 sm:text-xl">
             Feeling major FOMO right? <br />Let's build the community together.
           </h2>
-          <div class="mt-10 flex items-center justify-center gap-x-6 lg:mt-0 lg:shrink-0">
+          <div class="mt-8 flex flex-col items-center justify-center gap-y-2 gap-x-6 lg:mt-0 lg:shrink-0">
             <.link
               navigate={~p"/subscribe"}
               class="rounded-md bg-purple-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-purple-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-600"
             >
               Do it!
             </.link>
-            <.link navigate={~p"/about"} class="text-sm/6 font-semibold text-gray-900">
+            <.link navigate={~p"/about"} class="text-sm/6 text-gray-600">
               Learn more <span aria-hidden="true">→</span>
             </.link>
           </div>

--- a/lib/greecex_web/live/home_live.ex
+++ b/lib/greecex_web/live/home_live.ex
@@ -106,7 +106,7 @@ defmodule GreecexWeb.HomeLive do
           <h2 class="max-w-2xl text-2xl font-semibold tracking-tight text-gray-900 sm:text-xl">
             Feeling major FOMO right? <br />Let's build the community together.
           </h2>
-          <div class="mt-10 flex items-center gap-x-6 lg:mt-0 lg:shrink-0">
+          <div class="mt-10 flex items-center justify-center gap-x-6 lg:mt-0 lg:shrink-0">
             <.link
               navigate={~p"/subscribe"}
               class="rounded-md bg-purple-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-purple-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-600"


### PR DESCRIPTION
![Screenshot 2025-02-26 at 12 00 49 PM](https://github.com/user-attachments/assets/c56a1b31-fe2a-4099-8d9d-365d9542fdea)
![Screenshot 2025-02-26 at 12 01 28 PM](https://github.com/user-attachments/assets/0c9efd98-4419-4cd4-9e0f-97dcc578f936)

Each change is in a separate commit, justifications here for readability. Happy to iterate, or feel free to cherry-pick or close if you disagree.

commit f87f7855ae5cef0c178ac1f9b1157013e83ab753
Author: Jerry Cheung <jollyjerry@gmail.com>
Date:   Wed Feb 26 11:48:36 2025 -0800

    rm redundant px-6
    
    There's inline padding on <main> above
    This removes excess whitespace in small viewports

commit 8e05877772d9329313c9b679089d40295755ca81
Author: Jerry Cheung <jollyjerry@gmail.com>
Date:   Wed Feb 26 11:50:37 2025 -0800

    group Subscribe with paragraph above
    
    button felt unanchored floating in the middle.
    decrease top space so it is grouped with the hero

commit 2eddc05a3a1d403c5e35ed48571043c075d34241
Author: Jerry Cheung <jollyjerry@gmail.com>
Date:   Wed Feb 26 11:53:34 2025 -0800

    center h2
    
    better flow down the center with the center layout

commit 1c4aa66c524980c557b8c639bfc76199875564cc
Author: Jerry Cheung <jollyjerry@gmail.com>
Date:   Wed Feb 26 11:55:03 2025 -0800

    increase h2 size
    
    for contrast against bullets

commit fe8ab9f2d2934c6b4d01ae065e258562d2979bef
Author: Jerry Cheung <jollyjerry@gmail.com>
Date:   Wed Feb 26 11:56:57 2025 -0800

    rm redundant padding
    
    so it aligns with rest of page

commit 3453e760584ca287862e68ad50c140356c3045b1
Author: Jerry Cheung <jollyjerry@gmail.com>
Date:   Wed Feb 26 11:57:32 2025 -0800

    center Do it!

commit 4a8cdcfbc1649c8227c1a46b26a30bca9649e10b (HEAD -> main, jch/main)
Author: Jerry Cheung <jollyjerry@gmail.com>
Date:   Wed Feb 26 12:00:00 2025 -0800

    center learn more, same gray as links below